### PR TITLE
Currently returns 0 to OS even if tests fail.

### DIFF
--- a/lunitx.lua
+++ b/lunitx.lua
@@ -13,6 +13,9 @@ atexit(function()
         print(emsg)
         os.exit(1)
     end
+    if lunit.stats.failed > 0 then
+      os.exit(1)
+    end
 end)
 
 return lunit


### PR DESCRIPTION
Hi there, I was using lunitx but noticed that it returns 0 to the OS even if tests fail.  Enclosed is a simple change that returns 1 if any tests fail.

It looks like there's an error handler that does this already if the xpcall() fails.  I'm not sure what situations would cause this to happen so I didn't touch that branch.

Cheers,
Josh
