### PR TITLE
New skip function

### DIFF
--- a/lakeconfig.lua
+++ b/lakeconfig.lua
@@ -1,0 +1,138 @@
+function vc_version()
+  local VER = lake.compiler_version()
+  MSVC_VER = ({
+    [15] = '9';
+    [16] = '10';
+  })[VER.MAJOR] or ''
+  return MSVC_VER
+end
+
+local function arkey(t)
+  assert(type(t) == 'table')
+  local keys = {}
+  for k in pairs(t) do
+    assert(type(k) == 'number')
+    table.insert(keys, k)
+  end
+  table.sort(keys)
+  return keys
+end
+
+local function ikeys(t)
+  local keys = arkey(t)
+  local i = 0
+  return function()
+    i = i + 1
+    local k = keys[i]
+    if k == nil then return end
+    return k, t[k]
+  end
+end
+
+local function expand(arr, t)
+  if t == nil then return arr end
+
+  if type(t) ~= 'table' then
+    table.insert(arr, t)
+    return arr
+  end
+
+  for _, v in ikeys(t) do
+    expand(arr, v)
+  end
+
+  return arr
+end
+
+function L(...)
+  return expand({}, {...})
+end
+
+J = J or path.join
+
+IF = IF or lake.choose or choose
+
+function prequire(...)
+  local ok, mod = pcall(require, ...)
+  if ok then return mod end
+end
+
+function each_join(dir, list)
+  for i, v in ipairs(list) do
+    list[i] = path.join(dir, v)
+  end
+  return list
+end
+
+function run(file, cwd)
+  print()
+  print("run " .. file)
+  if not TESTING then
+    if cwd then lake.chdir(cwd) end
+    local status, code = utils.execute( LUA_RUNNER .. ' ' .. file )
+    if cwd then lake.chdir("<") end
+    print()
+    return status, code
+  end
+  return true, 0
+end
+
+function run_test(name, params)
+  local test_dir = J(ROOT, 'test')
+  local cmd = J(test_dir, name)
+  if params then cmd = cmd .. ' ' .. params end
+  local ok = run(cmd, test_dir)
+  print("TEST " .. cmd .. (ok and ' - pass!' or ' - fail!'))
+end
+
+function spawn(file, cwd)
+  local winapi = prequire "winapi"
+  if not winapi then
+    print(file, ' error: Test needs winapi!')
+    return false
+  end
+  print("spawn " .. file)
+  if not TESTING then
+    if cwd then lake.chdir(cwd) end
+    assert(winapi.shell_exec(nil, LUA_RUNNER, file, cwd))
+    if cwd then lake.chdir("<") end
+    print()
+  end
+  return true
+end
+
+function as_bool(v,d)
+  if v == nil then return not not d end
+  local n = tonumber(v)
+  if n == 0 then return false end
+  if n then return true end
+  return false
+end
+
+-----------------------
+-- needs --
+-----------------------
+
+lake.define_need('lua53', function()
+  return {
+    incdir = J(ENV.LUA_DIR_5_3, 'include');
+    libdir = J(ENV.LUA_DIR_5_3, 'lib');
+    libs = {'lua53'};
+  }
+end)
+
+lake.define_need('lua52', function()
+  return {
+    incdir = J(ENV.LUA_DIR_5_2, 'include');
+    libdir = J(ENV.LUA_DIR_5_2, 'lib');
+    libs = {'lua52'};
+  }
+end)
+
+lake.define_need('lua51', function()
+  return {
+    incdir = J(ENV.LUA_DIR, 'include');
+    libdir = J(ENV.LUA_DIR, 'lib');
+    libs = {'lua5.1'};
+  }
+end)

--- a/lakefile
+++ b/lakefile
@@ -2,7 +2,11 @@ J = assert(J or path.join)
 
 PROJECT = 'lunit'
 
-if LUA_VER == '5.2' then
+if LUA_VER == '5.3' then
+  LUA_NEED = 'lua53'
+  LUA_DIR  = ENV.LUA_DIR_5_3 or ENV.LUA_DIR
+  LUA_RUNNER = 'lua53'
+elseif LUA_VER == '5.2' then
   LUA_NEED = 'lua52'
   LUA_DIR  = ENV.LUA_DIR_5_2 or ENV.LUA_DIR
   LUA_RUNNER = 'lua52'

--- a/lakefile
+++ b/lakefile
@@ -1,0 +1,38 @@
+J = assert(J or path.join)
+
+PROJECT = 'lunit'
+
+if LUA_VER == '5.2' then
+  LUA_NEED = 'lua52'
+  LUA_DIR  = ENV.LUA_DIR_5_2 or ENV.LUA_DIR
+  LUA_RUNNER = 'lua52'
+else
+  LUA_NEED = 'lua'
+  LUA_DIR  = ENV.LUA_DIR
+  LUA_RUNNER = 'lua'
+end
+
+ROOT    = ROOT or J(LUA_DIR,'libs',PROJECT)
+LUADIR  = LUADIR or J(ROOT, 'share')
+LIBDIR  = LIBDIR or J(ROOT, 'share')
+TESTDIR = J(ROOT, 'test')
+
+install = target('install', {
+  file.group{odir = LUADIR;  recurse = true; src = J('lua',  '*.*' )};
+  file.group{odir = TESTDIR; recurse = true; src = J('test', '*.*' )};
+})
+
+local function run(file, cwd)
+  print()
+  print("run " .. file)
+  if not TESTING then
+    if cwd then lake.chdir(cwd) end
+    os.execute( LUA_RUNNER .. ' ' .. file )
+    if cwd then lake.chdir("<") end
+    print()
+  end
+end
+
+target('test', install, function()
+  run(J(TESTDIR,'selftest.lua'), TESTDIR)
+end)

--- a/lua/lunit.lua
+++ b/lua/lunit.lua
@@ -70,6 +70,7 @@ local function TEST_CASE(name)
   if not IS_LUA52 then
     module(name, package.seeall, lunit.testcase)
     setfenv(2, _M)
+    return _M
   else
     return lunit.module(name, 'seeall')
   end

--- a/lua/lunit.lua
+++ b/lua/lunit.lua
@@ -195,16 +195,54 @@ local function format_arg(arg)
 end
 
 
-local function selected(map, name)
+local selected
+do 
+  local conv = {
+    ["^"] = "%^",
+    ["$"] = "%$",
+    ["("] = "%(",
+    [")"] = "%)",
+    ["%"] = "%%",
+    ["."] = "%.",
+    ["["] = "%[",
+    ["]"] = "%]",
+    ["+"] = "%+",
+    ["-"] = "%-",
+    ["?"] = ".",
+    ["*"] = ".*"
+  }
+
+  local function lunitpat2luapat(str)
+    --return "^" .. string.gsub(str, "%W", conv) .. "$"
+    -- Above was very annoying, if I want to run all the tests having to do with
+    -- RSS, I want to be able to do "-t rss"   not "-t \*rss\*".
+    return string_gsub(str, "%W", conv)
+  end
+
+  local function in_patternmap(map, name)
+    if map[name] == true then
+      return true
+    else
+      for _, pat in ipairs(map) do
+        if string_find(name, pat) then
+          return true
+        end
+      end
+    end
+    return false
+  end
+
+  selected = function (map, name)
     if not map then
-        return true
+      return true
     end
 
     local m = {}
     for k,v in pairs(map) do
-        m[k] = lunitpat2luapat(v)
+      m[k] = lunitpat2luapat(v)
     end
     return in_patternmap(m, name)
+  end
 end
 
 
@@ -447,7 +485,6 @@ do
 end
 
 
-
 local function key_iter(t, k)
     return (next(t,k))
 end
@@ -542,8 +579,6 @@ do
 end
 
 
-
-
 function lunit.runtest(tcname, testname)
   orig_assert( is_string(tcname) )
   orig_assert( is_string(testname) )
@@ -583,7 +618,6 @@ end
 traceback_hide(runtest)
 
 
-
 function lunit.run(testpatterns)
   clearstats()
   if (not getrunner()) then
@@ -611,58 +645,6 @@ function lunit.loadonly()
   report("done")
   return stats
 end
-
-
-
-
-
-
-
-
-
-local lunitpat2luapat
-do 
-  local conv = {
-    ["^"] = "%^",
-    ["$"] = "%$",
-    ["("] = "%(",
-    [")"] = "%)",
-    ["%"] = "%%",
-    ["."] = "%.",
-    ["["] = "%[",
-    ["]"] = "%]",
-    ["+"] = "%+",
-    ["-"] = "%-",
-    ["?"] = ".",
-    ["*"] = ".*"
-  }
-  function lunitpat2luapat(str)
-    --return "^" .. string.gsub(str, "%W", conv) .. "$"
-    -- Above was very annoying, if I want to run all the tests having to do with
-    -- RSS, I want to be able to do "-t rss"   not "-t \*rss\*".
-    return string_gsub(str, "%W", conv)
-  end
-end
-
-
-
-local function in_patternmap(map, name)
-  if map[name] == true then
-    return true
-  else
-    for _, pat in ipairs(map) do
-      if string_find(name, pat) then
-        return true
-      end
-    end
-  end
-  return false
-end
-
-
-
-
-
 
 
 

--- a/lua/lunit/console.lua
+++ b/lua/lunit/console.lua
@@ -49,28 +49,16 @@
 --]]
 
 
-lunit = require "lunit"
+local lunit  = require "lunit"
+local string = require "string"
+local io     = require "io"
+local table  = require "table"
 
-local lunit_console
-
-if _VERSION >= 'Lua 5.2' then
-
-    lunit_console = setmetatable({},{__index = _ENV})
-    _ENV = lunit_console
-
-else
-
-    module( "lunit-console", package.seeall )
-    lunit_console = _M
-
-end
-
-
+local _M = {}
 
 local function printformat(format, ...)
   io.write( string.format(format, ...) )
 end
-
 
 local columns_printed = 0
 
@@ -87,11 +75,9 @@ local function writestatus(char)
   columns_printed = columns_printed + 1
 end
 
-
 local msgs = {}
 
-
-function begin()
+function _M.begin()
   local total_tc = 0
   local total_tests = 0
 
@@ -107,19 +93,16 @@ function begin()
   printformat("Loaded testsuite with %d tests in %d testcases.\n\n", total_tests, total_tc)
 end
 
-
-function run(testcasename, testname)
+function _M.run(testcasename, testname)
   -- NOP
 end
 
-
-function err(fullname, message, traceback)
+function _M.err(fullname, message, traceback)
   writestatus("E")
   msgs[#msgs+1] = "Error! ("..fullname.."):\n"..message.."\n\t"..table.concat(traceback, "\n\t") .. "\n"
 end
 
-
-function fail(fullname, where, message, usermessage)
+function _M.fail(fullname, where, message, usermessage)
   writestatus("F")
   local text =  "Failure ("..fullname.."):\n"..
                 where..": "..message.."\n"
@@ -131,14 +114,23 @@ function fail(fullname, where, message, usermessage)
   msgs[#msgs+1] = text
 end
 
+function _M.skip(fullname, where, message, usermessage)
+  writestatus("S")
+  local text =  "Skip ("..fullname.."):\n"..
+                where..": "..message.."\n"
 
-function pass(testcasename, testname)
+  if usermessage then
+    text = text .. where..": "..usermessage.."\n"
+  end
+
+  msgs[#msgs+1] = text
+end
+
+function _M.pass(testcasename, testname)
   writestatus(".")
 end
 
-
-
-function done()
+function _M.done()
   printformat("\n\n%d Assertions checked.\n", lunit.stats.assertions )
   print()
 
@@ -146,11 +138,8 @@ function done()
     printformat( "%3d) %s\n", i, msg )
   end
 
-  printformat("Testsuite finished (%d passed, %d failed, %d errors).\n",
-      lunit.stats.passed, lunit.stats.failed, lunit.stats.errors )
+  printformat("Testsuite finished (%d passed, %d failed, %d errors, %d skipped).\n",
+      lunit.stats.passed, lunit.stats.failed, lunit.stats.errors, lunit.stats.skipped )
 end
 
-
-return lunit_console
-
-
+return _M

--- a/lua/lunitx.lua
+++ b/lua/lunitx.lua
@@ -13,7 +13,7 @@ atexit(function()
         print(emsg)
         os.exit(1)
     end
-    if lunit.stats.failed > 0 then
+    if lunit.stats.failed > 0 or lunit.stats.errors > 0 then
       os.exit(1)
     end
 end)

--- a/rockspecs/lunitx-scm.mot.skip-0.rockspec
+++ b/rockspecs/lunitx-scm.mot.skip-0.rockspec
@@ -18,7 +18,7 @@ description = {
   license = "MIT/X11"
 }
 dependencies = {
-  "lua >= 5.1, <= 5.2"
+  "lua >= 5.1, < 5.4"
 }
 build = {
   copy_directories = {},

--- a/rockspecs/lunitx-scm.mot.skip-0.rockspec
+++ b/rockspecs/lunitx-scm.mot.skip-0.rockspec
@@ -1,0 +1,37 @@
+package = "lunitx"
+version = "scm.mot.skip-0"
+source = {
+  url = "git://github.com/moteus/lunit.git",
+  branch = "moteus-skip"
+}
+description = {
+  summary = "Lunitx is a unit testing framework for lua, written in lua.",
+  detailed = [[
+    Lunitx is a unit testing framework for lua, written in lua,
+    based heavily on Lunit 0.5, but modified to work with Lua 5.2.
+    Lunitx provides 27 assert functions, and a few misc functions
+    for usage in an easy unit testing framework.
+    Lunit comes with a test suite to test itself. The testsuite
+    consists of approximately 710 assertions.
+  ]],
+  homepage = "https://github.com/dcurrie/lunit",
+  license = "MIT/X11"
+}
+dependencies = {
+  "lua >= 5.1, <= 5.2"
+}
+build = {
+  copy_directories = {},
+  type = "builtin",
+  modules = {
+    ["lunit"] = "lua/lunit.lua",
+    ["lunitx"] = "lua/lunitx.lua",
+    ["lunit.console"] = "lua/lunit/console.lua",
+    ["lunitx.atexit"] = "lua/lunitx/atexit.lua",
+  },
+  install = {
+    bin = {
+      ["lunit.sh"] = "extra/lunit.sh",
+    }
+  }
+}

--- a/rockspecs/lunitx-scm.mot.skip-0.rockspec
+++ b/rockspecs/lunitx-scm.mot.skip-0.rockspec
@@ -1,8 +1,8 @@
 package = "lunitx"
 version = "scm.mot.skip-0"
 source = {
-  url = "git://github.com/moteus/lunit.git",
-  branch = "moteus-skip"
+  url = "https://github.com/moteus/lunit/archive/moteus-skip.zip",
+  dir = "lunit-moteus-skip"
 }
 description = {
   summary = "Lunitx is a unit testing framework for lua, written in lua.",

--- a/test/selftest.lua
+++ b/test/selftest.lua
@@ -67,7 +67,7 @@ function test()
     "assert_userdata", "assert_not_userdata", "assert_pass", "assert_error",
     "assert_error_match", "fail", "clearstats",
     "is_nil", "is_boolean", "is_number", "is_string", "is_table", "is_function",
-    "is_thread", "is_userdata", "module", "TEST_CASE"
+    "is_thread", "is_userdata", "module", "TEST_CASE", "skip"
   }
 
   local tablenames = {

--- a/test/selftest.lua
+++ b/test/selftest.lua
@@ -106,6 +106,11 @@ end
 -- the stdlib error() function to signal errors instead of fail().
 local _ENV = TEST_CASE "lunit.selftest.basics"
 
+function test_case_env()
+  assert_not_nil(_ENV)
+  if _M then assert_equal(_M, _ENV) end
+end
+
 function test_fail()
   local ok, errmsg
 


### PR DESCRIPTION
Skip function allow break current test and report some message.
But this test count as passed.
```lua
function test_optional()
  if not has_module_foo then skip"Module foo not found" end
  -- do test
end
```
See: https://travis-ci.org/moteus/lua-pop3 (build #16.2)
Test could not be passed because of lpeg. So i skip them.

Also this commit has few minor fixes.
lunitx ignores errors in tests
lunit.sh -t ... rises error

I think there still error in lunit.sh.
I test it on MinGW.
When i run `lunit.sh -t * test.lua` $options contain `-t test.lua test.lua`
