### PR TITLE
added Lua 5.5 support `+` tests on CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,45 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        lua-version:
+          - 5.1
+          - 5.2
+          - 5.3
+          - 5.4
+          - 5.5
+          - luajit
+          - openresty
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Lua and LuaRocks
+        uses: luau-project/setup-lua@51636d53d779571382f453a69b42f46d73ca1c1f # v1.1.0
+        with:
+          lua-version: ${{ matrix.lua-version }}
+
+      - name: Print Lua version
+        run: lua -v
+
+      - name: Print LuaRocks version
+        run: luarocks --version
+
+      - name: Print LuaRocks config
+        run: luarocks config
+
+      - name: Install lunitx using the development rockspec
+        run: luarocks make "rockspecs/lunitx-dev-1.rockspec"
+
+      - name: Run tests
+        run: lua "test/selftest.lua"

--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -1,9 +1,9 @@
 
-                 Lunit Release 0.8.1
+                 Lunit Release 0.8.2
                 =====================
 
 Lunitx is a unit testing framework for lua, written in lua, 
-based heavily on Lunit 0.5, but modified to work with Lua 5.2, 5.3, and 5.4
+based heavily on Lunit 0.5, but modified to work with Lua 5.2, 5.3, 5.4, and 5.5
 
 Lunitx provides 27 assert functions, and a few misc functions
 for usage in an easy unit testing framework.

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 
 
+Release 0.8.2:
+        Tested compatibility with Lua 5.5, and adjusted rockspec
+
 Release 0.8.1:
         Tested compatibility with Lua 5.4, and adjusted rockspec
 

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
-This is lunitx Version 0.8.1, an extended version of Lunit
-for Lua 5.2, 5.3, and 5.4.
+This is lunitx Version 0.8.2, an extended version of Lunit
+for Lua 5.2, 5.3, 5.4, and 5.5.
 
 Lunit is a unit testing framework for lua.
 

--- a/rockspecs/lunitx-0.8-2.rockspec
+++ b/rockspecs/lunitx-0.8-2.rockspec
@@ -1,0 +1,36 @@
+package = "lunitx"
+version = "0.8-2"
+source = {
+  url = "git+https://github.com/dcurrie/lunit.git",
+  tag = "0.8.2"
+}
+description = {
+  summary = "Lunitx is a unit testing framework for lua, written in lua.",
+  detailed = [[
+    Lunitx is a unit testing framework for lua, written in lua,
+    based heavily on Lunit 0.5, but modified to work with Lua 5.2.
+    Lunitx provides 27 assert functions, and a few misc functions
+    for usage in an easy unit testing framework.
+    Lunit comes with a test suite to test itself. The testsuite
+    consists of approximately 710 assertions.
+  ]],
+  homepage = "https://github.com/dcurrie/lunit",
+  license = "MIT/X11"
+}
+dependencies = {
+  "lua >= 5.1, < 5.6"
+}
+build = {
+  type = "builtin",
+  modules = {
+    ["lunit"] = "lua/lunit.lua",
+    ["lunitx"] = "lua/lunitx.lua",
+    ["lunit.console"] = "lua/lunit/console.lua",
+    ["lunitx.atexit"] = "lua/lunitx/atexit.lua",
+  },
+  install = {
+    bin = {
+      ["lunit.sh"] = "extra/lunit.sh",
+    }
+  }
+}

--- a/rockspecs/lunitx-dev-1.rockspec
+++ b/rockspecs/lunitx-dev-1.rockspec
@@ -1,0 +1,36 @@
+package = "lunitx"
+version = "dev-1"
+source = {
+  url = "git+https://github.com/dcurrie/lunit.git",
+  branch = "master"
+}
+description = {
+  summary = "Lunitx is a unit testing framework for lua, written in lua.",
+  detailed = [[
+    Lunitx is a unit testing framework for lua, written in lua,
+    based heavily on Lunit 0.5, but modified to work with Lua 5.2.
+    Lunitx provides 27 assert functions, and a few misc functions
+    for usage in an easy unit testing framework.
+    Lunit comes with a test suite to test itself. The testsuite
+    consists of approximately 710 assertions.
+  ]],
+  homepage = "https://github.com/dcurrie/lunit",
+  license = "MIT/X11"
+}
+dependencies = {
+  "lua >= 5.1, < 5.6"
+}
+build = {
+  type = "builtin",
+  modules = {
+    ["lunit"] = "lua/lunit.lua",
+    ["lunitx"] = "lua/lunitx.lua",
+    ["lunit.console"] = "lua/lunit/console.lua",
+    ["lunitx.atexit"] = "lua/lunitx/atexit.lua",
+  },
+  install = {
+    bin = {
+      ["lunit.sh"] = "extra/lunit.sh",
+    }
+  }
+}


### PR DESCRIPTION
## Description

@dcurrie 

added Lua 5.5 support `+` tests on CI

## Changes

* did a set of changes similar to commit [https://github.com/dcurrie/lunit/commit/c6e6e8b4dbaacfb4cd15dcaa6629710a16077376](https://github.com/dcurrie/lunit/commit/c6e6e8b4dbaacfb4cd15dcaa6629710a16077376) to add Lua 5.5 support
* added Continuous Integration (CI) to run on push / pull requests
* added a development rockspec (`rockspecs\lunitx-dev-1.rockspec`) to run CI

> [!NOTE]
> 
> Also added a rockspec named `rockspecs\lunitx-0.8-2.rockspec`, which assumes a future tag `0.8.2`, to be uploaded to LuaRocks

## PS

In case you find it useful, can you push a `0.8.2` tag and publish `rockspecs\lunitx-0.8-2.rockspec` to LuaRocks website?